### PR TITLE
Auto search

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ export default class GooglePlaceSearchInput extends React.Component {
 		}
 
 		this.autocompleteService = new window.google.maps.places.AutocompleteService();
+
+		if (this.props.value) {
+			this._getPlace(this.props.value);
+		}
 	}
 
 	_getPlace = inputValue => {


### PR DESCRIPTION
If a value is provided we trigger search automatically so that we can display results as soon as the widget is loaded. This also enables remove location button as soon as the widget is opened.